### PR TITLE
Fixed the Coveralls badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/apiaryio/blueprint-transactions.png?branch=master)](https://travis-ci.org/apiaryio/blueprint-transactions)
 [![Dependency Status](https://david-dm.org/apiaryio/blueprint-transactions.png)](https://david-dm.org/apiaryio/blueprint-transactions)
 [![devDependency Status](https://david-dm.org/apiaryio/blueprint-transactions/dev-status.png)](https://david-dm.org/apiaryio/blueprint-transactions#info=devDependencies)
-[![Coverage Status](https://coveralls.io/repos/apiaryio/blueprint-transactions/badge.svg?branch=master&service=github)](https://coveralls.io/github/apiaryio/blueprint-transactions?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/apiaryio/blueprint-transactions/badge.svg?branch=master)](https://coveralls.io/github/apiaryio/blueprint-transactions?branch=master)
 
 [![NPM](https://nodei.co/npm/blueprint-transactions.png)](https://nodei.co/npm/blueprint-transactions/)
 


### PR DESCRIPTION
Without this Coveralls (probably) fail to detect we already have this badge in README and they bother me with banner "add our badge!" :fist: 
